### PR TITLE
PHP 8.4 deprecation fixes

### DIFF
--- a/src/Exception/ActiveContainerNotFoundException.php
+++ b/src/Exception/ActiveContainerNotFoundException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class ActiveContainerNotFoundException extends LogicException
 {
-    public function __construct(Throwable $previous = null)
+    public function __construct(?Throwable $previous = null)
     {
         parent::__construct("Active container not found", 0, $previous);
     }

--- a/src/Exception/ActiveExecutionContextNotFoundException.php
+++ b/src/Exception/ActiveExecutionContextNotFoundException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class ActiveExecutionContextNotFoundException extends LogicException
 {
-    public function __construct(Throwable $previous = null)
+    public function __construct(?Throwable $previous = null)
     {
         parent::__construct("Active test, fixture or step not found", 0, $previous);
     }

--- a/src/Exception/ActiveStepNotFoundException.php
+++ b/src/Exception/ActiveStepNotFoundException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class ActiveStepNotFoundException extends LogicException
 {
-    public function __construct(Throwable $previous = null)
+    public function __construct(?Throwable $previous = null)
     {
         parent::__construct("Active step not found", 0, $previous);
     }

--- a/src/Exception/ActiveTestNotFoundException.php
+++ b/src/Exception/ActiveTestNotFoundException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class ActiveTestNotFoundException extends LogicException
 {
-    public function __construct(Throwable $previous = null)
+    public function __construct(?Throwable $previous = null)
     {
         parent::__construct("Active test or fixture not found", 0, $previous);
     }

--- a/src/Exception/InvalidMethodNameException.php
+++ b/src/Exception/InvalidMethodNameException.php
@@ -13,7 +13,7 @@ final class InvalidMethodNameException extends \DomainException
 {
     public function __construct(
         private mixed $methodName,
-        Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         $methodDescription = gettype($this->methodName);
         if (is_object($this->methodName)) {

--- a/src/Io/Exception/DirectoryNotCreatedException.php
+++ b/src/Io/Exception/DirectoryNotCreatedException.php
@@ -12,7 +12,7 @@ final class DirectoryNotCreatedException extends RuntimeException
     public function __construct(
         private string $directory,
         ?string $message = null,
-        Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct($this->buildMessage($message), 0, $previous);
     }

--- a/src/Io/Exception/DirectoryNotResolvedException.php
+++ b/src/Io/Exception/DirectoryNotResolvedException.php
@@ -12,7 +12,7 @@ final class DirectoryNotResolvedException extends RuntimeException
     public function __construct(
         private string $directory,
         ?string $message = null,
-        Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct($this->buildMessage($message), 0, $previous);
     }

--- a/src/Io/Exception/InvalidDirectoryException.php
+++ b/src/Io/Exception/InvalidDirectoryException.php
@@ -11,7 +11,7 @@ final class InvalidDirectoryException extends RuntimeException
 {
     public function __construct(
         private string $directory,
-        Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct("Not a directory: {$this->directory}", 0, $previous);
     }

--- a/src/Io/Exception/IoFailedException.php
+++ b/src/Io/Exception/IoFailedException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class IoFailedException extends RuntimeException
 {
-    public function __construct(?string $message = null, Throwable $previous = null)
+    public function __construct(?string $message = null, ?Throwable $previous = null)
     {
         parent::__construct($this->buildMessage($message), 0, $previous);
     }

--- a/src/Io/Exception/StreamCopyFailedException.php
+++ b/src/Io/Exception/StreamCopyFailedException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class StreamCopyFailedException extends RuntimeException
 {
-    public function __construct(?string $message = null, Throwable $previous = null)
+    public function __construct(?string $message = null, ?Throwable $previous = null)
     {
         parent::__construct($this->buildMessage($message), 0, $previous);
     }

--- a/src/Io/Exception/StreamOpenFailedException.php
+++ b/src/Io/Exception/StreamOpenFailedException.php
@@ -12,7 +12,7 @@ final class StreamOpenFailedException extends RuntimeException
     public function __construct(
         private string $link,
         ?string $message = null,
-        Throwable $previous = null,
+        ?Throwable $previous = null,
     ) {
         parent::__construct(
             $this->buildMessage($message),

--- a/src/Io/Exception/StreamWriteFailedException.php
+++ b/src/Io/Exception/StreamWriteFailedException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class StreamWriteFailedException extends RuntimeException
 {
-    public function __construct(?string $message = null, Throwable $previous = null)
+    public function __construct(?string $message = null, ?Throwable $previous = null)
     {
         parent::__construct($this->buildMessage($message), 0, $previous);
     }

--- a/src/Model/Exception/InvalidSeverityException.php
+++ b/src/Model/Exception/InvalidSeverityException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 final class InvalidSeverityException extends DomainException
 {
-    public function __construct(private string $severity, Throwable $previous = null)
+    public function __construct(private string $severity, ?Throwable $previous = null)
     {
         parent::__construct("Invalid severity: $this->severity", 0, $previous);
     }


### PR DESCRIPTION
Prominent deprecation in PHP 8.4:
This is a prominent deprecation in PHP 8.4 and legacy PHP applications will likely cause deprecation notices due to this change in PHP 8.4. The [suggested replacement](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated#change) is straight-forward, safe, and works in PHP 7.1 and later.