### PR TITLE
CI/Psaml fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,18 +30,19 @@ jobs:
           - "--prefer-lowest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v6
 
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-        
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          tools: composer:v2
           extensions: pcntl, posix
           coverage: xdebug
           ini-values: error_reporting=E_ALL
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
 
       - name: Install dependencies
         run: composer update

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "phpunit/phpunit": "^9.6.8",
     "psalm/plugin-phpunit": "^0.18.4",
     "squizlabs/php_codesniffer": "^3.7.2",
-    "vimeo/psalm": "^5.12"
+    "vimeo/psalm": "^5.17"
   },
   "autoload": {
     "psr-4": {

--- a/src/Model/JsonSerializableTrait.php
+++ b/src/Model/JsonSerializableTrait.php
@@ -30,8 +30,9 @@ trait JsonSerializableTrait
      */
     final public function jsonSerialize(): array
     {
+        $thisObjectVars = get_object_vars($this);
         $includedProperties = array_filter(
-            get_object_vars($this),
+            $thisObjectVars,
             fn (string $key): bool => !in_array($key, $this->excludeFromSerialization(), true),
             ARRAY_FILTER_USE_KEY,
         );

--- a/test/AllureLifecycleTest.php
+++ b/test/AllureLifecycleTest.php
@@ -875,7 +875,6 @@ class AllureLifecycleTest extends TestCase
             ->with(
                 self::callback(
                     function (AttachmentResult $attachmentResult) use (&$removeAttachmentResults): bool {
-                        /** @psalm-var list<AttachmentResult> $removeAttachmentResults */
                         $removeAttachmentResults[] = $attachmentResult;
 
                         return true;
@@ -889,7 +888,6 @@ class AllureLifecycleTest extends TestCase
             ->with(
                 self::callback(
                     function (TestResult $testResult) use (&$removeTestResults): bool {
-                        /** @psalm-var list<TestResult> $removeTestResults */
                         $removeTestResults[] = $testResult;
 
                         return true;
@@ -2752,7 +2750,6 @@ class AllureLifecycleTest extends TestCase
             ->with(
                 self::callback(
                     function (AttachmentResult $attachmentResult) use (&$removeAttachmentResults): bool {
-                        /** @psalm-var list<AttachmentResult> $removeAttachmentResults */
                         $removeAttachmentResults[] = $attachmentResult;
 
                         return true;

--- a/test/AllureTest.php
+++ b/test/AllureTest.php
@@ -242,7 +242,7 @@ class AllureTest extends TestCase
     }
 
     #[DisplayName('b')]
-    public function titledStep(): void
+    public function titledStep(StepContextInterface $_): void
     {
     }
 
@@ -293,7 +293,7 @@ class AllureTest extends TestCase
     }
 
     #[Parameter('b', 'c')]
-    public function parametrizedStep(): void
+    public function parametrizedStep(StepContextInterface $_): void
     {
     }
 


### PR DESCRIPTION
The PR fixes the CI build pipeline and several errors caused by new Psalm rules. Here is the list of changes:

  - Fix `composer: command not found` on Mac OS GitHub runners
  - Fix Psaml error: `MixedArgumentTypeCoercion` in `src/Model/JsonSerializableTrait.php`
  - Fix multiple Psalm errors: `UnnecessaryVarAnnotation ` in `test/AllureLifecycleTest.php`
  - Fix multiple Psalm errors `PossiblyInvalidArgument` in `test/AllureTest.php`
  - Bump `actions/checkout` to `v6`.
  - Bump `vimeo/psalm` to `^5.17` to avoid `MixedArrayAssignment` when using `--prefer-lowest` in CI.
