### PR TITLE
Add global attachments and errors API

### DIFF
--- a/src/Allure.php
+++ b/src/Allure.php
@@ -219,7 +219,7 @@ final class Allure
             $message = $value;
         }
 
-        $factory = self::getInstance()
+        $factory = $instance
             ->getLifecycleConfig()
             ->getResultFactory();
 

--- a/src/Allure.php
+++ b/src/Allure.php
@@ -138,6 +138,107 @@ final class Allure
             ->addAttachment($attachment, $dataSource);
     }
 
+    /**
+     * Writes a global attachment that isn't related to a particular test, step, or fixture.
+     */
+    public static function globalAttachment(
+        string $name,
+        string $content,
+        ?string $type = null,
+        ?string $fileExtension = null,
+    ): void {
+        self::getInstance()->doAddGlobalAttachment(
+            DataSourceFactory::fromString($content),
+            $name,
+            $type,
+            $fileExtension,
+        );
+    }
+
+    /**
+     * Writes a global attachment that isn't related to a particular test, step, or fixture.
+     */
+    public static function globalAttachmentFile(
+        string $name,
+        string $file,
+        ?string $type = null,
+        ?string $fileExtension = null
+    ): void {
+        self::getInstance()->doAddGlobalAttachment(
+            DataSourceFactory::fromFile($file),
+            $name,
+            $type,
+            $fileExtension,
+        );
+    }
+
+    private function doAddGlobalAttachment(
+        DataSourceInterface $dataSource,
+        string $name,
+        ?string $type = null,
+        ?string $fileExtension = null,
+    ): void {
+        $factory = self::getInstance()
+            ->getLifecycleConfig()
+            ->getResultFactory();
+
+        $attachment = $factory
+            ->createGlobalAttachment()
+            ->setName($name)
+            ->setType($type)
+            ->setFileExtension($fileExtension);
+
+        $globals = $factory
+            ->createGlobals()
+            ->addAttachment($attachment);
+
+        $lifecycle = $this->doGetLifecycle();
+
+        $lifecycle->addGlobalAttachment($attachment, $dataSource);
+        $lifecycle->addGlobals($globals);
+    }
+
+    /**
+     * Writes a global error that isn't related to a specific test, step, or fixture.
+     * If an exception instance is provided, fills the message and trace from it.
+     * Otherwise, a string message must be provided, optionally followed by a trace.
+     *
+     * @param $value An exception
+     */
+    public static function globalError(Throwable|string $value, ?string $trace = null): void
+    {
+        $instance = self::getInstance();
+        $lifecycleBuilder = $instance->getLifecycleConfig();
+
+        if ($value instanceof Throwable) {
+            $statusDetails = $lifecycleBuilder
+                ->getStatusDetector()
+                ->getStatusDetails($value);
+
+            $message = $statusDetails?->getMessage();
+            $trace = $statusDetails?->getTrace();
+        } else {
+            $message = $value;
+        }
+
+        $factory = self::getInstance()
+            ->getLifecycleConfig()
+            ->getResultFactory();
+
+        $error = $factory
+            ->createGlobalError()
+            ->setMessage($message)
+            ->setTrace($trace);
+
+        $globals = $factory
+            ->createGlobals()
+            ->addError($error);
+
+        $instance
+            ->doGetLifecycle()
+            ->addGlobals($globals);
+    }
+
     public static function epic(string $value): void
     {
         self::getInstance()->doLabel(Label::epic($value));

--- a/src/Allure.php
+++ b/src/Allure.php
@@ -202,8 +202,6 @@ final class Allure
      * Writes a global error that isn't related to a specific test, step, or fixture.
      * If an exception instance is provided, fills the message and trace from it.
      * Otherwise, a string message must be provided, optionally followed by a trace.
-     *
-     * @param $value An exception
      */
     public static function globalError(Throwable|string $value, ?string $trace = null): void
     {

--- a/src/AllureLifecycle.php
+++ b/src/AllureLifecycle.php
@@ -18,6 +18,8 @@ use Qameta\Allure\Io\ResultsWriterInterface;
 use Qameta\Allure\Model\AttachmentResult;
 use Qameta\Allure\Model\ContainerResult;
 use Qameta\Allure\Model\ExecutionContextInterface;
+use Qameta\Allure\Model\GlobalAttachment;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\FixtureResult;
 use Qameta\Allure\Model\ResultInterface;
 use Qameta\Allure\Model\Stage;
@@ -547,6 +549,38 @@ final class AllureLifecycle implements AllureLifecycleInterface
 
             return;
         }
+
+        $this->writeAttachment($attachment, $data, $context->getUuid());
+    }
+
+    public function addGlobalAttachment(GlobalAttachment $attachment, DataSourceInterface $data): void
+    {
+        $this->writeAttachment($attachment, $data);
+    }
+
+    public function addGlobals(Globals $globals): void
+    {
+        $this->notifier->beforeGlobalsWrite($globals);
+        try {
+            if (!$globals->getExcluded()) {
+                $this->resultsWriter->writeGlobals($globals);
+            }
+        } catch (Throwable $e) {
+            $this->logException(
+                'Globals (UUID: {uuid}) not added',
+                $e,
+                ['uuid' => $globals->getUuid()],
+            );
+            $this->notifier->onLifecycleError($e);
+        }
+        $this->notifier->afterGlobalsWrite($globals);
+    }
+
+    private function writeAttachment(
+        AttachmentResult $attachment,
+        DataSourceInterface $data,
+        ?string $parentUuid = null
+    ): void {
         $this->notifier->beforeAttachmentWrite($attachment);
         try {
             if (!$attachment->getExcluded()) {
@@ -556,7 +590,7 @@ final class AllureLifecycle implements AllureLifecycleInterface
             $this->logException(
                 'Attachment (UUID: {uuid}) not added (parent UUID: {parentUuid})',
                 $e,
-                ['uuid' => $attachment->getUuid(), 'parentUuid' => $context->getUuid()],
+                ['uuid' => $attachment->getUuid(), 'parentUuid' => $parentUuid],
             );
             $this->notifier->onLifecycleError($e);
         }

--- a/src/AllureLifecycleInterface.php
+++ b/src/AllureLifecycleInterface.php
@@ -7,6 +7,8 @@ namespace Qameta\Allure;
 use Qameta\Allure\Io\DataSourceInterface;
 use Qameta\Allure\Model\AttachmentResult;
 use Qameta\Allure\Model\ContainerResult;
+use Qameta\Allure\Model\GlobalAttachment;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\FixtureResult;
 use Qameta\Allure\Model\StepResult;
 use Qameta\Allure\Model\TestResult;
@@ -56,4 +58,8 @@ interface AllureLifecycleInterface
     public function stopStep(?string $uuid = null): ?string;
 
     public function addAttachment(AttachmentResult $attachment, DataSourceInterface $data): void;
+
+    public function addGlobalAttachment(GlobalAttachment $attachment, DataSourceInterface $data): void;
+
+    public function addGlobals(Globals $globals): void;
 }

--- a/src/Hook/AfterGlobalsWriteHookInterface.php
+++ b/src/Hook/AfterGlobalsWriteHookInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Hook;
+
+use Qameta\Allure\Model\Globals;
+
+interface AfterGlobalsWriteHookInterface extends LifecycleHookInterface
+{
+    public function afterGlobalsWrite(Globals $globals): void;
+}

--- a/src/Hook/BeforeGlobalsWriteHookInterface.php
+++ b/src/Hook/BeforeGlobalsWriteHookInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Hook;
+
+use Qameta\Allure\Model\Globals;
+
+interface BeforeGlobalsWriteHookInterface extends LifecycleHookInterface
+{
+    public function beforeGlobalsWrite(Globals $globals): void;
+}

--- a/src/Internal/HooksNotifier.php
+++ b/src/Internal/HooksNotifier.php
@@ -13,6 +13,7 @@ use Qameta\Allure\Hook\AfterContainerWriteHookInterface;
 use Qameta\Allure\Hook\AfterFixtureStartHookInterface;
 use Qameta\Allure\Hook\AfterFixtureStopHookInterface;
 use Qameta\Allure\Hook\AfterFixtureUpdateHookInterface;
+use Qameta\Allure\Hook\AfterGlobalsWriteHookInterface;
 use Qameta\Allure\Hook\AfterStepStartHookInterface;
 use Qameta\Allure\Hook\AfterStepStopHookInterface;
 use Qameta\Allure\Hook\AfterStepUpdateHookInterface;
@@ -29,6 +30,7 @@ use Qameta\Allure\Hook\BeforeContainerWriteHookInterface;
 use Qameta\Allure\Hook\BeforeFixtureStartHookInterface;
 use Qameta\Allure\Hook\BeforeFixtureStopHookInterface;
 use Qameta\Allure\Hook\BeforeFixtureUpdateHookInterface;
+use Qameta\Allure\Hook\BeforeGlobalsWriteHookInterface;
 use Qameta\Allure\Hook\BeforeStepStartHookInterface;
 use Qameta\Allure\Hook\BeforeStepStopHookInterface;
 use Qameta\Allure\Hook\BeforeStepUpdateHookInterface;
@@ -42,6 +44,7 @@ use Qameta\Allure\Hook\OnLifecycleErrorHookInterface;
 use Qameta\Allure\Model\AttachmentResult;
 use Qameta\Allure\Model\ContainerResult;
 use Qameta\Allure\Model\FixtureResult;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\ResultType;
 use Qameta\Allure\Model\StepResult;
 use Qameta\Allure\Model\TestResult;
@@ -360,6 +363,24 @@ final class HooksNotifier implements HooksNotifierInterface
             ResultType::unknown(),
             OnLifecycleErrorHookInterface::class,
             static fn (OnLifecycleErrorHookInterface $hook) => $hook->onLifecycleError($error),
+        );
+    }
+
+    public function beforeGlobalsWrite(Globals $globals): void
+    {
+        $this->forEachHook(
+            $globals->getResultType(),
+            BeforeGlobalsWriteHookInterface::class,
+            static fn (BeforeGlobalsWriteHookInterface $hook) => $hook->beforeGlobalsWrite($globals),
+        );
+    }
+
+    public function afterGlobalsWrite(Globals $globals): void
+    {
+        $this->forEachHook(
+            $globals->getResultType(),
+            AfterGlobalsWriteHookInterface::class,
+            static fn (AfterGlobalsWriteHookInterface $hook) => $hook->afterGlobalsWrite($globals),
         );
     }
 

--- a/src/Internal/HooksNotifierInterface.php
+++ b/src/Internal/HooksNotifierInterface.php
@@ -12,6 +12,7 @@ use Qameta\Allure\Hook\AfterContainerWriteHookInterface;
 use Qameta\Allure\Hook\AfterFixtureStartHookInterface;
 use Qameta\Allure\Hook\AfterFixtureStopHookInterface;
 use Qameta\Allure\Hook\AfterFixtureUpdateHookInterface;
+use Qameta\Allure\Hook\AfterGlobalsWriteHookInterface;
 use Qameta\Allure\Hook\AfterStepStartHookInterface;
 use Qameta\Allure\Hook\AfterStepStopHookInterface;
 use Qameta\Allure\Hook\AfterStepUpdateHookInterface;
@@ -28,6 +29,7 @@ use Qameta\Allure\Hook\BeforeContainerWriteHookInterface;
 use Qameta\Allure\Hook\BeforeFixtureStartHookInterface;
 use Qameta\Allure\Hook\BeforeFixtureStopHookInterface;
 use Qameta\Allure\Hook\BeforeFixtureUpdateHookInterface;
+use Qameta\Allure\Hook\BeforeGlobalsWriteHookInterface;
 use Qameta\Allure\Hook\BeforeStepStartHookInterface;
 use Qameta\Allure\Hook\BeforeStepStopHookInterface;
 use Qameta\Allure\Hook\BeforeStepUpdateHookInterface;
@@ -71,6 +73,8 @@ interface HooksNotifierInterface extends
     AfterStepStopHookInterface,
     BeforeAttachmentWriteHookInterface,
     AfterAttachmentWriteHookInterface,
-    OnLifecycleErrorHookInterface
+    OnLifecycleErrorHookInterface,
+    BeforeGlobalsWriteHookInterface,
+    AfterGlobalsWriteHookInterface
 {
 }

--- a/src/Internal/LifecycleBuilder.php
+++ b/src/Internal/LifecycleBuilder.php
@@ -98,6 +98,7 @@ final class LifecycleBuilder implements LifecycleBuilderInterface
     {
         return $this->resultFactory ??= new ResultFactory(
             $this->getUuidFactory(),
+            $this->getClock(),
         );
     }
 

--- a/src/Io/FileSystemResultsWriter.php
+++ b/src/Io/FileSystemResultsWriter.php
@@ -13,6 +13,7 @@ use Qameta\Allure\Io\Exception\StreamCopyFailedException;
 use Qameta\Allure\Io\Exception\StreamOpenFailedException;
 use Qameta\Allure\Model\AttachmentResult;
 use Qameta\Allure\Model\ContainerResult;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\TestResult;
 use Throwable;
 
@@ -44,6 +45,8 @@ class FileSystemResultsWriter implements ResultsWriterInterface
     private const RESULT_FILE_POSTFIX = '-result' . self::FILE_EXTENSION;
 
     private const CONTAINER_FILE_POSTFIX = '-container' . self::FILE_EXTENSION;
+
+    private const GLOBALS_FILE_POSTFIX = '-globals' . self::FILE_EXTENSION;
 
     private string $outputDirectory;
 
@@ -80,6 +83,14 @@ class FileSystemResultsWriter implements ResultsWriterInterface
         $source = $this->getAttachmentSource($attachment);
         $attachment->setSource($source);
         $this->write($source, $data);
+    }
+
+    public function writeGlobals(Globals $globals): void
+    {
+        $this->write(
+            $globals->getUuid() . self::GLOBALS_FILE_POSTFIX,
+            DataSourceFactory::fromSerializable($globals),
+        );
     }
 
     public function removeAttachment(AttachmentResult $attachment): void

--- a/src/Io/ResultsWriterInterface.php
+++ b/src/Io/ResultsWriterInterface.php
@@ -6,6 +6,7 @@ namespace Qameta\Allure\Io;
 
 use Qameta\Allure\Model\AttachmentResult;
 use Qameta\Allure\Model\ContainerResult;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\TestResult;
 
 interface ResultsWriterInterface
@@ -15,6 +16,8 @@ interface ResultsWriterInterface
     public function writeTest(TestResult $test): void;
 
     public function writeAttachment(AttachmentResult $attachment, DataSourceInterface $data): void;
+
+    public function writeGlobals(Globals $globals): void;
 
     public function removeAttachment(AttachmentResult $attachment): void;
 

--- a/src/Model/AttachmentResult.php
+++ b/src/Model/AttachmentResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\Model;
 
-final class AttachmentResult extends Result
+class AttachmentResult extends Result
 {
     protected ?string $name = null;
 

--- a/src/Model/AttachmentResult.php
+++ b/src/Model/AttachmentResult.php
@@ -24,7 +24,7 @@ class AttachmentResult extends Result
         return $this->name;
     }
 
-    public function setName(?string $name): self
+    public function setName(?string $name): static
     {
         $this->name = $name;
 
@@ -36,7 +36,7 @@ class AttachmentResult extends Result
         return $this->source;
     }
 
-    public function setSource(?string $source): self
+    public function setSource(?string $source): static
     {
         $this->source = $source;
 
@@ -48,7 +48,7 @@ class AttachmentResult extends Result
         return $this->type;
     }
 
-    public function setType(?string $type): self
+    public function setType(?string $type): static
     {
         $this->type = $type;
         return $this;
@@ -59,7 +59,7 @@ class AttachmentResult extends Result
         return $this->fileExtension;
     }
 
-    public function setFileExtension(?string $fileExtension): self
+    public function setFileExtension(?string $fileExtension): static
     {
         $this->fileExtension = $fileExtension;
 

--- a/src/Model/GlobalAttachment.php
+++ b/src/Model/GlobalAttachment.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Model;
+
+use DateTimeImmutable;
+
+final class GlobalAttachment extends AttachmentResult
+{
+    protected SerializableDate $timestamp;
+
+    public function __construct(
+        string $uuid,
+        DateTimeImmutable $timestamp,
+        ?string $name = null,
+        ?string $source = null,
+        ?string $type = null,
+        ?string $fileExtension = null,
+    ) {
+        parent::__construct($uuid);
+
+        $this
+            ->setName($name)
+            ->setSource($source)
+            ->setType($type)
+            ->setFileExtension($fileExtension);
+
+        $this->timestamp = new SerializableDate($timestamp);
+    }
+
+    public function getTimestamp(): DateTimeImmutable
+    {
+        return $this->timestamp->getDate();
+    }
+
+    public function setTimestamp(DateTimeImmutable $timestamp): self
+    {
+        $this->timestamp = new SerializableDate($timestamp);
+
+        return $this;
+    }
+}

--- a/src/Model/GlobalError.php
+++ b/src/Model/GlobalError.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Model;
+
+use DateTimeImmutable;
+
+final class GlobalError extends StatusDetails
+{
+    protected SerializableDate $timestamp;
+
+    public function __construct(
+        DateTimeImmutable $timestamp,
+        ?bool $known = null,
+        ?bool $muted = null,
+        ?bool $flaky = null,
+        ?string $message = null,
+        ?string $trace = null,
+    ) {
+        parent::__construct(
+            known: $known,
+            muted: $muted,
+            flaky: $flaky,
+            message: $message,
+            trace: $trace,
+        );
+
+        $this->timestamp = new SerializableDate($timestamp);
+    }
+
+    public function getTimestamp(): DateTimeImmutable
+    {
+        return $this->timestamp->getDate();
+    }
+
+    public function setTimestamp(DateTimeImmutable $timestamp): self
+    {
+        $this->timestamp = new SerializableDate($timestamp);
+
+        return $this;
+    }
+}

--- a/src/Model/Globals.php
+++ b/src/Model/Globals.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Qameta\Allure\Model;
+
+final class Globals extends Result
+{
+    /**
+     * @var list<GlobalAttachment>
+     */
+    protected array $attachments = [];
+
+    /**
+     * @var list<GlobalError>
+     */
+    protected array $errors = [];
+
+    /**
+     * @return list<GlobalAttachment>
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
+    }
+
+    public function addAttachment(GlobalAttachment $attachment): self
+    {
+        array_push($this->attachments, $attachment);
+
+        return $this;
+    }
+
+    /**
+     * @return list<GlobalError>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    public function addError(GlobalError $error): self
+    {
+        array_push($this->errors, $error);
+
+        return $this;
+    }
+
+    public function getResultType(): ResultType
+    {
+        return ResultType::globals();
+    }
+
+    /**
+     * @return list<ResultInterface>
+     */
+    final public function getNestedResults(): array
+    {
+        return [
+            ...$this->attachments,
+        ];
+    }
+}

--- a/src/Model/ResultFactory.php
+++ b/src/Model/ResultFactory.php
@@ -46,6 +46,11 @@ final class ResultFactory implements ResultFactoryInterface
         );
     }
 
+    public function createGlobals(): Globals
+    {
+        return new Globals(uuid: $this->createUuid());
+    }
+
     private function createUuid(): string
     {
         return $this

--- a/src/Model/ResultFactory.php
+++ b/src/Model/ResultFactory.php
@@ -13,8 +13,7 @@ final class ResultFactory implements ResultFactoryInterface
     public function __construct(
         private UuidFactoryInterface $uuidFactory,
         private ClockInterface $clock,
-    )
-    {
+    ) {
     }
 
     public function createContainer(): ContainerResult

--- a/src/Model/ResultFactory.php
+++ b/src/Model/ResultFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Qameta\Allure\Model;
 
 use Ramsey\Uuid\UuidFactoryInterface;
+use DateTimeImmutable;
 
 final class ResultFactory implements ResultFactoryInterface
 {
@@ -35,6 +36,14 @@ final class ResultFactory implements ResultFactoryInterface
     public function createAttachment(): AttachmentResult
     {
         return new AttachmentResult($this->createUuid());
+    }
+
+    public function createGlobalAttachment(DateTimeImmutable $timestamp): GlobalAttachment
+    {
+        return new GlobalAttachment(
+            uuid: $this->createUuid(),
+            timestamp: $timestamp,
+        );
     }
 
     private function createUuid(): string

--- a/src/Model/ResultFactory.php
+++ b/src/Model/ResultFactory.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Qameta\Allure\Model;
 
 use Ramsey\Uuid\UuidFactoryInterface;
+use Qameta\Allure\Io\ClockInterface;
 use DateTimeImmutable;
 
 final class ResultFactory implements ResultFactoryInterface
 {
-    public function __construct(private UuidFactoryInterface $uuidFactory)
+    public function __construct(
+        private UuidFactoryInterface $uuidFactory,
+        private ClockInterface $clock,
+    )
     {
     }
 
@@ -38,11 +42,18 @@ final class ResultFactory implements ResultFactoryInterface
         return new AttachmentResult($this->createUuid());
     }
 
-    public function createGlobalAttachment(DateTimeImmutable $timestamp): GlobalAttachment
+    public function createGlobalError(): GlobalError
+    {
+        return new GlobalError(
+            timestamp: $this->now(),
+        );
+    }
+
+    public function createGlobalAttachment(): GlobalAttachment
     {
         return new GlobalAttachment(
             uuid: $this->createUuid(),
-            timestamp: $timestamp,
+            timestamp: $this->now(),
         );
     }
 
@@ -57,5 +68,10 @@ final class ResultFactory implements ResultFactoryInterface
             ->uuidFactory
             ->uuid4()
             ->toString();
+    }
+
+    private function now(): DateTimeImmutable
+    {
+        return $this->clock->now();
     }
 }

--- a/src/Model/ResultFactoryInterface.php
+++ b/src/Model/ResultFactoryInterface.php
@@ -18,5 +18,9 @@ interface ResultFactoryInterface
 
     public function createAttachment(): AttachmentResult;
 
-    public function createGlobalAttachment(DateTimeImmutable $timestamp): GlobalAttachment;
+    public function createGlobalError(): GlobalError;
+
+    public function createGlobalAttachment(): GlobalAttachment;
+
+    public function createGlobals(): Globals;
 }

--- a/src/Model/ResultFactoryInterface.php
+++ b/src/Model/ResultFactoryInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\Model;
 
-use DateTimeImmutable;
-
 interface ResultFactoryInterface
 {
     public function createContainer(): ContainerResult;

--- a/src/Model/ResultFactoryInterface.php
+++ b/src/Model/ResultFactoryInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\Model;
 
+use DateTimeImmutable;
+
 interface ResultFactoryInterface
 {
     public function createContainer(): ContainerResult;
@@ -15,4 +17,6 @@ interface ResultFactoryInterface
     public function createFixture(): FixtureResult;
 
     public function createAttachment(): AttachmentResult;
+
+    public function createGlobalAttachment(DateTimeImmutable $timestamp): GlobalAttachment;
 }

--- a/src/Model/ResultType.php
+++ b/src/Model/ResultType.php
@@ -13,6 +13,7 @@ final class ResultType extends AbstractEnum
     private const STEP = 'step';
     private const ATTACHMENT = 'attachment';
     private const EXECUTABLE_CONTEXT = 'executable_context';
+    private const GLOBALS = 'globals';
 
     public static function unknown(): self
     {
@@ -47,5 +48,10 @@ final class ResultType extends AbstractEnum
     public static function executableContext(): self
     {
         return self::create(self::EXECUTABLE_CONTEXT);
+    }
+
+    public static function globals(): self
+    {
+        return self::create(self::GLOBALS);
     }
 }

--- a/src/Model/StatusDetails.php
+++ b/src/Model/StatusDetails.php
@@ -6,7 +6,7 @@ namespace Qameta\Allure\Model;
 
 use JsonSerializable;
 
-final class StatusDetails implements JsonSerializable
+class StatusDetails implements JsonSerializable
 {
     use JsonSerializableTrait;
 

--- a/src/Model/StatusDetails.php
+++ b/src/Model/StatusDetails.php
@@ -24,7 +24,7 @@ class StatusDetails implements JsonSerializable
         return $this->known;
     }
 
-    public function makeKnown(?bool $known): self
+    public function makeKnown(?bool $known): static
     {
         $this->known = $known;
 
@@ -36,7 +36,7 @@ class StatusDetails implements JsonSerializable
         return $this->muted;
     }
 
-    public function makeMuted(?bool $muted): self
+    public function makeMuted(?bool $muted): static
     {
         $this->muted = $muted;
 
@@ -48,7 +48,7 @@ class StatusDetails implements JsonSerializable
         return $this->flaky;
     }
 
-    public function makeFlaky(?bool $flaky): self
+    public function makeFlaky(?bool $flaky): static
     {
         $this->flaky = $flaky;
 
@@ -60,7 +60,7 @@ class StatusDetails implements JsonSerializable
         return $this->message;
     }
 
-    public function setMessage(?string $message): self
+    public function setMessage(?string $message): static
     {
         $this->message = $message;
 
@@ -72,7 +72,7 @@ class StatusDetails implements JsonSerializable
         return $this->trace;
     }
 
-    public function setTrace(?string $trace): self
+    public function setTrace(?string $trace): static
     {
         $this->trace = $trace;
 

--- a/test/AllureLifecycleTest.php
+++ b/test/AllureLifecycleTest.php
@@ -25,6 +25,8 @@ use Qameta\Allure\Model\AttachmentResult;
 use Qameta\Allure\Model\ContainerResult;
 use Qameta\Allure\Model\ExecutionContextInterface;
 use Qameta\Allure\Model\FixtureResult;
+use Qameta\Allure\Model\GlobalAttachment;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\Stage;
 use Qameta\Allure\Model\StepResult;
 use Qameta\Allure\Model\StorableResultInterface;
@@ -4439,6 +4441,133 @@ class AllureLifecycleTest extends TestCase
             ->method('writeAttachment')
             ->with(self::identicalTo($attachment), self::identicalTo($data));
         $lifecycle->addAttachment($attachment, $data);
+    }
+
+    public function testAddGlobalAttachment_AttachmentNotExcluded_WriterWritesSameAttachmentWithGivenData(): void
+    {
+        $resultsWriter = $this->createMock(ResultsWriterInterface::class);
+        $lifecycle = new AllureLifecycle(
+            $this->createStub(LoggerInterface::class),
+            $this->createClock(),
+            $resultsWriter,
+            $this->createStub(HooksNotifierInterface::class),
+            $this->createMock(ResultStorageInterface::class),
+            new ThreadContext(),
+        );
+
+        $attachment = new GlobalAttachment(uuid: '-', timestamp: new DateTimeImmutable());
+        $data = $this->createStub(DataSourceInterface::class);
+        $resultsWriter
+            ->expects(self::once())
+            ->method('writeAttachment')
+            ->with(self::identicalTo($attachment), self::identicalTo($data));
+        $lifecycle->addGlobalAttachment($attachment, $data);
+    }
+
+    public function testAddGlobals_NoExceptionThrownDuringWrite_NotifiesHooksWithoutError(): void
+    {
+        $hooksNotifier = $this->createMock(HooksNotifierInterface::class);
+        $lifecycle = new AllureLifecycle(
+            $this->createStub(LoggerInterface::class),
+            $this->createClock(),
+            $this->createStub(ResultsWriterInterface::class),
+            $hooksNotifier,
+            $this->createMock(ResultStorageInterface::class),
+            new ThreadContext(),
+        );
+
+        $globals = new Globals('-');
+        $hooksNotifier
+            ->expects(self::once())
+            ->id('before')
+            ->method('beforeGlobalsWrite')
+            ->with(self::identicalTo($globals));
+        $hooksNotifier
+            ->expects(self::never())
+            ->method('onLifecycleError');
+        $hooksNotifier
+            ->expects(self::once())
+            ->after('before')
+            ->method('afterGlobalsWrite')
+            ->with(self::identicalTo($globals));
+        $lifecycle->addGlobals($globals);
+    }
+
+    public function testAddGlobals_ExceptionThrownDuringWrite_NotifiesHooksWithError(): void
+    {
+        $error = new Exception();
+        $resultsWriter = $this->createStub(ResultsWriterInterface::class);
+        $resultsWriter
+            ->method('writeGlobals')
+            ->willThrowException($error);
+        $hooksNotifier = $this->createMock(HooksNotifierInterface::class);
+        $lifecycle = new AllureLifecycle(
+            $this->createStub(LoggerInterface::class),
+            $this->createClock(),
+            $resultsWriter,
+            $hooksNotifier,
+            $this->createMock(ResultStorageInterface::class),
+            new ThreadContext(),
+        );
+
+        $globals = new Globals('-');
+        $hooksNotifier
+            ->expects(self::once())
+            ->id('before')
+            ->method('beforeGlobalsWrite')
+            ->with(self::identicalTo($globals));
+        $hooksNotifier
+            ->expects(self::once())
+            ->id('error')
+            ->after('before')
+            ->method('onLifecycleError')
+            ->with(self::identicalTo($error));
+        $hooksNotifier
+            ->expects(self::once())
+            ->after('error')
+            ->method('afterGlobalsWrite')
+            ->with(self::identicalTo($globals));
+        $lifecycle->addGlobals($globals);
+    }
+
+    public function testAddGlobals_WriterWritesObject(): void
+    {
+        $resultsWriter = $this->createMock(ResultsWriterInterface::class);
+        $lifecycle = new AllureLifecycle(
+            $this->createStub(LoggerInterface::class),
+            $this->createClock(),
+            $resultsWriter,
+            $this->createStub(HooksNotifierInterface::class),
+            $this->createMock(ResultStorageInterface::class),
+            new ThreadContext(),
+        );
+
+        $globals = new Globals("-");
+        $resultsWriter
+            ->expects(self::once())
+            ->method('writeGlobals')
+            ->with(self::identicalTo($globals));
+        $lifecycle->addGlobals($globals);
+    }
+
+    public function testAddGlobals_Excluded_ShouldNotBeWritten(): void
+    {
+        $resultsWriter = $this->createMock(ResultsWriterInterface::class);
+        $lifecycle = new AllureLifecycle(
+            $this->createStub(LoggerInterface::class),
+            $this->createClock(),
+            $resultsWriter,
+            $this->createStub(HooksNotifierInterface::class),
+            $this->createMock(ResultStorageInterface::class),
+            new ThreadContext(),
+        );
+
+        $globals = new Globals("-");
+        $globals->setExcluded(true);
+        $resultsWriter
+            ->expects(self::never())
+            ->method('writeGlobals');
+        $lifecycle->addGlobals($globals);
     }
 
     public function testAddAttachment_AttachmentExcluded_WriterNeverWritesAttachment(): void

--- a/test/AllureTest.php
+++ b/test/AllureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Qameta\Allure\Test;
 
+use DateTimeImmutable;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Qameta\Allure\Allure;
@@ -15,6 +16,9 @@ use Qameta\Allure\Io\ResultsWriterInterface;
 use Qameta\Allure\Io\StreamDataSource;
 use Qameta\Allure\Io\StringDataSource;
 use Qameta\Allure\Model\AttachmentResult;
+use Qameta\Allure\Model\GlobalAttachment;
+use Qameta\Allure\Model\GlobalError;
+use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\LinkType;
 use Qameta\Allure\Model\ParameterMode;
 use Qameta\Allure\Model\ResultFactoryInterface;
@@ -480,6 +484,211 @@ class AllureTest extends TestCase
                 self::isInstanceOf(StreamDataSource::class),
             );
         Allure::attachmentFile('b', 'c');
+    }
+
+    /**
+     * @dataProvider providerAttachmentProperties
+     */
+    public function testGlobalAttachment_ResultFactoryProvidesAttachment_AttachmentAndGlobalsHaveGivenProperties(
+        string $name,
+        ?string $type,
+        ?string $fileExtension,
+    ): void {
+        $attachment = new GlobalAttachment(
+            uuid: '-',
+            timestamp: new DateTimeImmutable(),
+        );
+        $globals = new Globals("-");
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalAttachment($attachment, $globals),
+            ),
+        );
+
+        Allure::globalAttachment($name, 'b', $type, $fileExtension);
+
+        self::assertSame($name, $attachment->getName());
+        self::assertSame($type, $attachment->getType());
+        self::assertSame($fileExtension, $attachment->getFileExtension());
+        self::assertEquals([$attachment], $globals->getAttachments());
+    }
+
+    public function testGlobalAttachment_ResultFactoryProvidesAttachment_AttachmentAndGlobalsAreAddedToLifecycle(): void
+    {
+        $attachment = new GlobalAttachment(
+            uuid: '-',
+            timestamp: new DateTimeImmutable(),
+        );
+        $globals = new Globals("-");
+        $lifecycle = $this->createMock(AllureLifecycleInterface::class);
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalAttachment($attachment, $globals),
+                $lifecycle,
+            ),
+        );
+
+        $lifecycle
+            ->expects(self::once())
+            ->method('addGlobalAttachment')
+            ->with(
+                self::identicalTo($attachment),
+                self::isInstanceOf(StringDataSource::class),
+            );
+        $lifecycle
+            ->expects(self::once())
+            ->method('addGlobals')
+            ->with(
+                self::identicalTo($globals),
+            );
+
+        Allure::globalAttachment('b', 'c');
+    }
+
+    /**
+     * @dataProvider providerAttachmentProperties
+     */
+    public function testGlobalAttachmentFile_ResultFactoryProvidesAttachment_AttachmentAndGlobalsHaveGivenProperties(
+        string $name,
+        ?string $type,
+        ?string $fileExtension,
+    ): void {
+        $attachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: new DateTimeImmutable(),
+        );
+        $globals = new Globals("-");
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalAttachment($attachment, $globals),
+            ),
+        );
+
+        Allure::globalAttachmentFile($name, "b", $type, $fileExtension);
+
+        self::assertSame($name, $attachment->getName());
+        self::assertSame($type, $attachment->getType());
+        self::assertSame($fileExtension, $attachment->getFileExtension());
+        self::assertEquals([$attachment], $globals->getAttachments());
+    }
+
+    public function testGlobalAttachmentFile_ResultFactoryProvidesAttachment_ObjsAddedToLifecycle(): void
+    {
+        $attachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: new DateTimeImmutable(),
+        );
+        $globals = new Globals("-");
+        $lifecycle = $this->createMock(AllureLifecycleInterface::class);
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalAttachment($attachment, $globals),
+                $lifecycle,
+            ),
+        );
+
+        $lifecycle
+            ->expects(self::once())
+            ->method('addGlobalAttachment')
+            ->with(
+                self::identicalTo($attachment),
+                self::isInstanceOf(StreamDataSource::class),
+            );
+        $lifecycle
+            ->expects(self::once())
+            ->method('addGlobals')
+            ->with(
+                self::identicalTo($globals),
+            );
+
+        Allure::globalAttachmentFile("b", "c");
+    }
+
+    public function testGlobalError_FromException_HasMessageAndTraceFromException(): void
+    {
+        $error = new GlobalError(new DateTimeImmutable());
+        $globals = new Globals("-");
+        $exception = new Exception();
+        $statusDetector = $this->createMock(StatusDetectorInterface::class);
+        $statusDetails = new StatusDetails();
+        $statusDetails
+            ->setMessage("foo")
+            ->setTrace("bar");
+        $statusDetector
+            ->method('getStatusDetails')
+            ->with(self::identicalTo($exception))
+            ->willReturn($statusDetails);
+
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                resultFactory: $this->createResultFactoryWithGlobalError($error, $globals),
+                statusDetector: $statusDetector,
+            ),
+        );
+
+        Allure::globalError($exception);
+
+        self::assertEquals("foo", $error->getMessage());
+        self::assertEquals("bar", $error->getTrace());
+        self::assertEquals([$error], $globals->getErrors());
+    }
+
+    public function testGlobalError_FromStrings_HasMessageAndTrace(): void
+    {
+        $error = new GlobalError(new DateTimeImmutable());
+        $globals = new Globals("-");
+
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalError($error, $globals),
+            ),
+        );
+
+        Allure::globalError("foo", "bar");
+
+        self::assertEquals("foo", $error->getMessage());
+        self::assertEquals("bar", $error->getTrace());
+        self::assertEquals([$error], $globals->getErrors());
+    }
+
+    public function testGlobalError_FromSingleString_HasMessageAndTrace(): void
+    {
+        $error = new GlobalError(new DateTimeImmutable());
+        $globals = new Globals("-");
+
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalError($error, $globals),
+            ),
+        );
+
+        Allure::globalError("foo");
+
+        self::assertEquals("foo", $error->getMessage());
+        self::assertNull($error->getTrace());
+        self::assertEquals([$error], $globals->getErrors());
+    }
+
+    public function testGlobalError_ResultFactoryProvidesErrort_GlobalsAddedToLifecycle(): void
+    {
+        $attachment = new GlobalError(new DateTimeImmutable());
+        $globals = new Globals("-");
+        $lifecycle = $this->createMock(AllureLifecycleInterface::class);
+        Allure::setLifecycleBuilder(
+            $this->createLifecycleBuilder(
+                $this->createResultFactoryWithGlobalError($attachment, $globals),
+                $lifecycle,
+            ),
+        );
+
+        $lifecycle
+            ->expects(self::once())
+            ->method('addGlobals')
+            ->with(
+                self::identicalTo($globals),
+            );
+
+        Allure::globalError("foo", "bar");
     }
 
     public function testEpic_GivenValue_TestHasMatchingLabel(): void
@@ -1086,6 +1295,38 @@ class AllureTest extends TestCase
 
         return $resultFactory;
     }
+
+
+    private function createResultFactoryWithGlobalAttachment(
+        GlobalAttachment $attachment,
+        Globals $globals
+    ): ResultFactoryInterface {
+        $resultFactory = $this->createStub(ResultFactoryInterface::class);
+        $resultFactory
+            ->method('createGlobalAttachment')
+            ->willReturn($attachment);
+        $resultFactory
+            ->method('createGlobals')
+            ->willReturn($globals);
+
+        return $resultFactory;
+    }
+
+    private function createResultFactoryWithGlobalError(
+        GlobalError $error,
+        Globals $globals
+    ): ResultFactoryInterface {
+        $resultFactory = $this->createStub(ResultFactoryInterface::class);
+        $resultFactory
+            ->method('createGlobalError')
+            ->willReturn($error);
+        $resultFactory
+            ->method('createGlobals')
+            ->willReturn($globals);
+
+        return $resultFactory;
+    }
+
 
     private function createResultFactoryWithTest(TestResult $test): ResultFactoryInterface
     {

--- a/test/Model/GlobalAttachmentTest.php
+++ b/test/Model/GlobalAttachmentTest.php
@@ -101,9 +101,7 @@ class GlobalAttachmentTest extends TestCase
          */
         $date = DateTimeImmutable::createFromFormat(
             DateTimeInterface::ISO8601,
-
-            // 1577874031000 milliseconds since epoch
-            "2020-01-01T10:20:31+00:00",
+            "2020-01-01T10:20:31+00:00", // 1577874031000 milliseconds since epoch
         );
         $globalAttachment = new GlobalAttachment(
             uuid: "-",

--- a/test/Model/GlobalAttachmentTest.php
+++ b/test/Model/GlobalAttachmentTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Test\Model;
+
+use PHPUnit\Framework\TestCase;
+use Qameta\Allure\Model\GlobalAttachment;
+use Qameta\Allure\Model\ResultFactory;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+use function json_decode;
+use function json_encode;
+
+/**
+ * @covers \Qameta\Allure\Model\GlobalAttachment
+ */
+class GlobalAttachmentTest extends TestCase
+{
+    public function testRequiredProperties_ReturnProvidedValue(): void
+    {
+        $date = new DateTimeImmutable();
+
+        $globalAttachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: $date,
+        );
+
+        self::assertEquals("-", $globalAttachment->getUuid());
+        self::assertEquals($date, $globalAttachment->getTimestamp());
+    }
+
+    public function testNonMandatoryProperties_WhenNotProvided_DefaultToNull(): void
+    {
+        $globalAttachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        self::assertNull($globalAttachment->getName());
+        self::assertNull($globalAttachment->getSource());
+        self::assertNull($globalAttachment->getType());
+        self::assertNull($globalAttachment->getFileExtension());
+    }
+
+    public function testNonMandatoryProperties_WhenProvided_EqualProvidedValues(): void
+    {
+        $globalAttachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: new DateTimeImmutable(),
+            name: "foo",
+            source: "bar",
+            type: "baz",
+            fileExtension: "qux",
+        );
+
+        self::assertEquals("foo", $globalAttachment->getName());
+        self::assertEquals("bar", $globalAttachment->getSource());
+        self::assertEquals("baz", $globalAttachment->getType());
+        self::assertEquals("qux", $globalAttachment->getFileExtension());
+    }
+
+    public function testGetTimestamp_AfterSetTimestamp_ReturnsUpdatedValue(): void
+    {
+        $globalAttachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        /**
+         * @var DateTimeImmutable
+         */
+        $expectedDate = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+            "2020-01-01T10:20:31+00:00",
+        );
+
+        $globalAttachment->setTimestamp($expectedDate);
+
+        self::assertEquals($expectedDate, $globalAttachment->getTimestamp());
+    }
+
+    public function testSetTimestamp_ReturnsObjectItself(): void
+    {
+        $globalAttachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        self::assertSame(
+            $globalAttachment,
+            $globalAttachment->setTimestamp(new DateTimeImmutable()),
+        );
+    }
+
+    public function testJsonSerialization_WithAllProperties_JsonContainsAllProperties(): void
+    {
+        /**
+         * @var DateTimeImmutable
+         */
+        $date = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+
+            // 1577874031000 milliseconds since epoch
+            "2020-01-01T10:20:31+00:00",
+        );
+        $globalAttachment = new GlobalAttachment(
+            uuid: "-",
+            timestamp: $date,
+            name: "foo",
+            source: "bar",
+            type: "baz",
+            fileExtension: "qux",
+        );
+
+        $json = json_encode($globalAttachment);
+
+        /** @var object */
+        $parsed = json_decode($json);
+
+        self::assertEquals(1577874031000, $parsed->timestamp);
+        self::assertEquals("foo", $parsed->name);
+        self::assertEquals("bar", $parsed->source);
+        self::assertEquals("baz", $parsed->type);
+    }
+}

--- a/test/Model/GlobalErrorTest.php
+++ b/test/Model/GlobalErrorTest.php
@@ -77,9 +77,7 @@ class GlobalErrorTest extends TestCase
          */
         $date = DateTimeImmutable::createFromFormat(
             DateTimeInterface::ISO8601,
-
-            // 1577874031000 milliseconds since epoch
-            "2020-01-01T10:20:31+00:00",
+            "2020-01-01T10:20:31+00:00", // 1577874031000 milliseconds since epoch
         );
         $globalError = new GlobalError(
             timestamp: $date,

--- a/test/Model/GlobalErrorTest.php
+++ b/test/Model/GlobalErrorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Test\Model;
+
+use PHPUnit\Framework\TestCase;
+use Qameta\Allure\Model\GlobalError;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+use function json_decode;
+use function json_encode;
+
+/**
+ * @covers \Qameta\Allure\Model\GlobalError
+ */
+class GlobalErrorTest extends TestCase
+{
+    public function testGetTimestamp_CreatedWithTimestampOnly_ReturnsProvidedValue(): void
+    {
+        $date = new DateTimeImmutable();
+        $globalError = new GlobalError($date);
+
+        self::assertEquals($date, $globalError->getTimestamp());
+    }
+
+    public function testStatusDetailsProperties_ConstructedWithAllArguments_ReturnProvidedValues(): void
+    {
+        $globalError = new GlobalError(
+            timestamp: new DateTimeImmutable(),
+            known: true,
+            muted: true,
+            flaky: true,
+            message: "foo",
+            trace: "bar",
+        );
+
+        self::assertTrue($globalError->isKnown());
+        self::assertTrue($globalError->isMuted());
+        self::assertTrue($globalError->isFlaky());
+        self::assertEquals("foo", $globalError->getMessage());
+        self::assertEquals("bar", $globalError->getTrace());
+    }
+
+    public function testGetTimestamp_AfterSetTimestamp_ReturnsUpdatedValue(): void
+    {
+        $globalError = new GlobalError(new DateTimeImmutable());
+
+        /**
+         * @var DateTimeImmutable
+         */
+        $expectedDate = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+            "2020-01-01T10:20:31+00:00",
+        );
+
+        $globalError->setTimestamp($expectedDate);
+
+        self::assertEquals($expectedDate, $globalError->getTimestamp());
+    }
+
+    public function testSetTimestamp_ReturnsObjectItself(): void
+    {
+        $globalError = new GlobalError(new DateTimeImmutable());
+
+        self::assertSame(
+            $globalError,
+            $globalError->setTimestamp(new DateTimeImmutable()),
+        );
+    }
+
+    public function testJsonSerialization_WithAllProperties_JsonContainsAllProperties(): void
+    {
+        /**
+         * @var DateTimeImmutable
+         */
+        $date = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+
+            // 1577874031000 milliseconds since epoch
+            "2020-01-01T10:20:31+00:00",
+        );
+        $globalError = new GlobalError(
+            timestamp: $date,
+            known: true,
+            muted: true,
+            flaky: true,
+            message: "foo",
+            trace: "bar",
+        );
+
+        $json = json_encode($globalError);
+
+        /** @var object */
+        $parsed = json_decode($json);
+
+        self::assertEquals(1577874031000, $parsed->timestamp);
+        self::assertEquals("foo", $parsed->message);
+        self::assertEquals("bar", $parsed->trace);
+        self::assertTrue($parsed->known);
+        self::assertTrue($parsed->muted);
+        self::assertTrue($parsed->flaky);
+    }
+}

--- a/test/Model/GlobalsTest.php
+++ b/test/Model/GlobalsTest.php
@@ -163,13 +163,10 @@ class GlobalsTest extends TestCase
          */
         $date1 = DateTimeImmutable::createFromFormat(
             DateTimeInterface::ISO8601,
-
-            // 1577874031000 milliseconds since epoch
-            "2020-01-01T10:20:31+00:00",
+            "2020-01-01T10:20:31+00:00", // 1577874031000 milliseconds since epoch
         );
 
-        // 1577874061000 milliseconds since epoch
-        $date2 = $date1->modify("+30 seconds");
+        $date2 = $date1->modify("+30 seconds"); // 1577874061000 milliseconds since epoch
 
         $globals = new Globals("-");
 

--- a/test/Model/GlobalsTest.php
+++ b/test/Model/GlobalsTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Test\Model;
+
+use PHPUnit\Framework\TestCase;
+use Qameta\Allure\Model\GlobalAttachment;
+use Qameta\Allure\Model\GlobalError;
+use Qameta\Allure\Model\Globals;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+use function json_decode;
+use function json_encode;
+
+/**
+ * @covers \Qameta\Allure\Model\Globals
+ */
+class GlobalsTest extends TestCase
+{
+    public function testGetUuid_Default_ReturnsProvidedValue(): void
+    {
+        $globals = new Globals("-");
+
+        self::assertEquals("-", $globals->getUuid());
+    }
+
+    public function testGetResultType_Always_ReturnsGlobals(): void
+    {
+        $globals = new Globals("-");
+
+        self::assertEquals("globals", (string)$globals->getResultType());
+    }
+
+    public function testGlobalProperties_Default_AreEmpty(): void
+    {
+        $globals = new Globals("-");
+
+        self::assertEquals([], $globals->getAttachments());
+        self::assertEquals([], $globals->getErrors());
+    }
+
+    public function testGetAttachments_AfterAttachmentAdded_ContainsSingleAttachment(): void
+    {
+        $globals = new Globals("-");
+        $attachment = new GlobalAttachment(
+            uuid: "-",
+            source: "foo",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $globals->addAttachment($attachment);
+
+
+        self::assertEquals([$attachment], $globals->getAttachments());
+    }
+
+    public function testAddAttachment_Always_ReturnsObjectItself(): void
+    {
+        $globals = new Globals("-");
+        $attachment = new GlobalAttachment(
+            uuid: "-",
+            source: "foo",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        self::assertSame($globals, $globals->addAttachment($attachment));
+    }
+
+    public function testGetAttachments_AfterTwoAttachmentsAdded_ContainsBothAttachments(): void
+    {
+        $globals = new Globals("-");
+        $attachment1 = new GlobalAttachment(
+            uuid: "-",
+            source: "foo",
+            timestamp: new DateTimeImmutable(),
+        );
+        $attachment2 = new GlobalAttachment(
+            uuid: "-",
+            source: "foo",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $globals
+            ->addAttachment($attachment1)
+            ->addAttachment($attachment2);
+
+
+        self::assertEquals([$attachment1, $attachment2], $globals->getAttachments());
+    }
+
+    public function testGetNestedResults_AfterMultipleItemsAdded_ContainsAllAttachmentsOnly(): void
+    {
+        $globals = new Globals("-");
+        $attachment1 = new GlobalAttachment(
+            uuid: "-",
+            source: "foo",
+            timestamp: new DateTimeImmutable(),
+        );
+        $attachment2 = new GlobalAttachment(
+            uuid: "-",
+            source: "foo",
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $globals
+            ->addAttachment($attachment1)
+            ->addAttachment($attachment2)
+            ->addError(new GlobalError(
+                timestamp: new DateTimeImmutable(),
+            ));
+
+
+        self::assertEquals([$attachment1, $attachment2], $globals->getNestedResults());
+    }
+
+    public function testGetErrors_AfterErrorAdded_ContainsSingleError(): void
+    {
+        $globals = new Globals("-");
+        $error = new GlobalError(
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $globals->addError($error);
+
+
+        self::assertEquals([$error], $globals->getErrors());
+    }
+
+    public function testAddError_Always_ReturnsObjectItself(): void
+    {
+        $globals = new Globals("-");
+        $error = new GlobalError(
+            timestamp: new DateTimeImmutable(),
+        );
+
+        self::assertSame($globals, $globals->addError($error));
+    }
+
+    public function testGetErrors_AfterTwoErrorsAdded_ContainsBothError(): void
+    {
+        $globals = new Globals("-");
+        $error1 = new GlobalError(
+            timestamp: new DateTimeImmutable(),
+        );
+        $error2 = new GlobalError(
+            timestamp: new DateTimeImmutable(),
+        );
+
+        $globals
+            ->addError($error1)
+            ->addError($error2);
+
+
+        self::assertEquals([$error1, $error2], $globals->getErrors());
+    }
+
+    public function testJsonSerialization_WithAllProperties_JsonContainsAllProperties(): void
+    {
+        /**
+         * @var DateTimeImmutable
+         */
+        $date1 = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+
+            // 1577874031000 milliseconds since epoch
+            "2020-01-01T10:20:31+00:00",
+        );
+
+        // 1577874061000 milliseconds since epoch
+        $date2 = $date1->modify("+30 seconds");
+
+        $globals = new Globals("-");
+
+        $globals
+            ->addAttachment(
+                new GlobalAttachment(
+                    uuid: "-",
+                    source: "foo",
+                    timestamp: $date1,
+                ),
+            )
+            ->addError(new GlobalError(timestamp: $date2));
+
+        $json = json_encode($globals);
+
+        /** @var object */
+        $parsed = json_decode($json);
+        /** @var array */
+        $parsedAttachments = $parsed->attachments;
+        /** @var array */
+        $parsedErrors = $parsed->errors;
+
+        self::assertCount(1, $parsedAttachments);
+        self::assertCount(1, $parsedErrors);
+
+        /** @var object */
+        $parsedAttachment = $parsedAttachments[0];
+        /** @var object */
+        $parsedError = $parsedErrors[0];
+
+        self::assertEquals($parsedAttachment->source, "foo");
+        self::assertEquals($parsedAttachment->timestamp, 1577874031000);
+        self::assertEquals($parsedError->timestamp, 1577874061000);
+    }
+}

--- a/test/Model/ResultFactoryTest.php
+++ b/test/Model/ResultFactoryTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Qameta\Allure\Model\ResultFactory;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactoryInterface;
+use DateTimeImmutable;
 
 /**
  * @covers \Qameta\Allure\Model\ResultFactory
@@ -87,5 +88,22 @@ class ResultFactoryTest extends TestCase
             '00000000-0000-0000-0000-000000000001',
             $resultFactory->createAttachment()->getUuid(),
         );
+    }
+
+    public function testCreateGlobalAttachment_WithSourceString_HasUuidSourceAndTimestamp(): void
+    {
+        $uuidFactory = $this->createStub(UuidFactoryInterface::class);
+        $uuid = Uuid::fromString("00000000-0000-0000-0000-000000000001");
+        $uuidFactory
+            ->method("uuid4")
+            ->willReturn($uuid);
+        $resultFactory = new ResultFactory($uuidFactory);
+        $date = new DateTimeImmutable();
+
+        $globalAttachment = $resultFactory->createGlobalAttachment($date);
+
+
+        self::assertEquals("00000000-0000-0000-0000-000000000001", $globalAttachment->getUuid());
+        self::assertEquals($date, $globalAttachment->getTimestamp());
     }
 }

--- a/test/Model/ResultFactoryTest.php
+++ b/test/Model/ResultFactoryTest.php
@@ -90,7 +90,7 @@ class ResultFactoryTest extends TestCase
         );
     }
 
-    public function testCreateGlobalAttachment_WithSourceString_HasUuidSourceAndTimestamp(): void
+    public function testCreateGlobalAttachment_FactoryProvidesUuid_HasUuidAndTimestamp(): void
     {
         $uuidFactory = $this->createStub(UuidFactoryInterface::class);
         $uuid = Uuid::fromString("00000000-0000-0000-0000-000000000001");
@@ -105,5 +105,20 @@ class ResultFactoryTest extends TestCase
 
         self::assertEquals("00000000-0000-0000-0000-000000000001", $globalAttachment->getUuid());
         self::assertEquals($date, $globalAttachment->getTimestamp());
+    }
+
+    public function testCreateGlobals_FactoryProvidesUuid_ResultHasSameUuid(): void
+    {
+        $uuidFactory = $this->createStub(UuidFactoryInterface::class);
+        $uuid = Uuid::fromString("00000000-0000-0000-0000-000000000001");
+        $uuidFactory
+            ->method("uuid4")
+            ->willReturn($uuid);
+        $resultFactory = new ResultFactory($uuidFactory);
+
+        $globals = $resultFactory->createGlobals();
+
+
+        self::assertEquals("00000000-0000-0000-0000-000000000001", $globals->getUuid());
     }
 }

--- a/test/Model/ResultFactoryTest.php
+++ b/test/Model/ResultFactoryTest.php
@@ -6,9 +6,11 @@ namespace Qameta\Allure\Test\Model;
 
 use PHPUnit\Framework\TestCase;
 use Qameta\Allure\Model\ResultFactory;
+use Qameta\Allure\Io\ClockInterface;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidFactoryInterface;
 use DateTimeImmutable;
+use DateTimeInterface;
 
 /**
  * @covers \Qameta\Allure\Model\ResultFactory
@@ -22,8 +24,9 @@ class ResultFactoryTest extends TestCase
         $uuidFactory
             ->method('uuid4')
             ->willReturn($uuid);
+        $clock = $this->createStub(ClockInterface::class);
 
-        $resultFactory = new ResultFactory($uuidFactory);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
         self::assertSame(
             '00000000-0000-0000-0000-000000000001',
             $resultFactory->createContainer()->getUuid(),
@@ -37,8 +40,9 @@ class ResultFactoryTest extends TestCase
         $uuidFactory
             ->method('uuid4')
             ->willReturn($uuid);
+        $clock = $this->createStub(ClockInterface::class);
 
-        $resultFactory = new ResultFactory($uuidFactory);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
         self::assertSame(
             '00000000-0000-0000-0000-000000000001',
             $resultFactory->createTest()->getUuid(),
@@ -52,8 +56,9 @@ class ResultFactoryTest extends TestCase
         $uuidFactory
             ->method('uuid4')
             ->willReturn($uuid);
+        $clock = $this->createStub(ClockInterface::class);
 
-        $resultFactory = new ResultFactory($uuidFactory);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
         self::assertSame(
             '00000000-0000-0000-0000-000000000001',
             $resultFactory->createStep()->getUuid(),
@@ -67,8 +72,9 @@ class ResultFactoryTest extends TestCase
         $uuidFactory
             ->method('uuid4')
             ->willReturn($uuid);
+        $clock = $this->createStub(ClockInterface::class);
 
-        $resultFactory = new ResultFactory($uuidFactory);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
         self::assertSame(
             '00000000-0000-0000-0000-000000000001',
             $resultFactory->createFixture()->getUuid(),
@@ -82,25 +88,57 @@ class ResultFactoryTest extends TestCase
         $uuidFactory
             ->method('uuid4')
             ->willReturn($uuid);
+        $clock = $this->createStub(ClockInterface::class);
 
-        $resultFactory = new ResultFactory($uuidFactory);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
         self::assertSame(
             '00000000-0000-0000-0000-000000000001',
             $resultFactory->createAttachment()->getUuid(),
         );
     }
 
-    public function testCreateGlobalAttachment_FactoryProvidesUuid_HasUuidAndTimestamp(): void
+    public function testCreateGlobalError_FactoryProvidesTimestamp_HasTimestamp(): void
     {
         $uuidFactory = $this->createStub(UuidFactoryInterface::class);
         $uuid = Uuid::fromString("00000000-0000-0000-0000-000000000001");
         $uuidFactory
             ->method("uuid4")
             ->willReturn($uuid);
-        $resultFactory = new ResultFactory($uuidFactory);
-        $date = new DateTimeImmutable();
+        $clock = $this->createStub(ClockInterface::class);
+        $date = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+            "2020-01-01T10:20:31+00:00",
+        );
+        $clock
+            ->method("now")
+            ->willReturn($date);
 
-        $globalAttachment = $resultFactory->createGlobalAttachment($date);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
+
+        $globalError = $resultFactory->createGlobalError();
+
+        self::assertEquals($date, $globalError->getTimestamp());
+    }
+
+    public function testCreateGlobalAttachment_FactoryProvidesUuidAndTimestamp_HasUuidAndTimestamp(): void
+    {
+        $uuidFactory = $this->createStub(UuidFactoryInterface::class);
+        $uuid = Uuid::fromString("00000000-0000-0000-0000-000000000001");
+        $uuidFactory
+            ->method("uuid4")
+            ->willReturn($uuid);
+        $clock = $this->createStub(ClockInterface::class);
+        $date = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ISO8601,
+            "2020-01-01T10:20:31+00:00",
+        );
+        $clock
+            ->method("now")
+            ->willReturn($date);
+
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
+
+        $globalAttachment = $resultFactory->createGlobalAttachment();
 
 
         self::assertEquals("00000000-0000-0000-0000-000000000001", $globalAttachment->getUuid());
@@ -114,7 +152,8 @@ class ResultFactoryTest extends TestCase
         $uuidFactory
             ->method("uuid4")
             ->willReturn($uuid);
-        $resultFactory = new ResultFactory($uuidFactory);
+        $clock = $this->createStub(ClockInterface::class);
+        $resultFactory = new ResultFactory($uuidFactory, $clock);
 
         $globals = $resultFactory->createGlobals();
 

--- a/test/Model/ResultTypeTest.php
+++ b/test/Model/ResultTypeTest.php
@@ -89,4 +89,15 @@ class ResultTypeTest extends TestCase
     {
         self::assertSame('executable_context', (string) ResultType::executableContext());
     }
+
+    public function testGlobals_CalledTwice_ReturnsSameInstance(): void
+    {
+        $resultType = ResultType::globals();
+        self::assertSame($resultType, ResultType::globals());
+    }
+
+    public function testGlobals_CastedToString_ReturnsMatchingValue(): void
+    {
+        self::assertSame('globals', (string) ResultType::globals());
+    }
 }

--- a/test/Model/TestResultTest.php
+++ b/test/Model/TestResultTest.php
@@ -22,7 +22,7 @@ class TestResultTest extends TestCase
 
         $titlePath = $testResult->getTitlePath();
 
-        self::assertEquals($titlePath, []);
+        self::assertEquals([], $titlePath);
     }
 
     public function testSetTitlePathReturnsObjectItself(): void
@@ -31,7 +31,7 @@ class TestResultTest extends TestCase
 
         $actual = $testResult->setTitlePath();
 
-        self::assertSame($actual, $testResult);
+        self::assertSame($testResult, $actual);
     }
 
     public function testTitlePathCanBeSet(): void
@@ -41,7 +41,7 @@ class TestResultTest extends TestCase
 
         $titlePath = $testResult->getTitlePath();
 
-        self::assertEquals($titlePath, ["foo", "bar", "baz"]);
+        self::assertEquals(["foo", "bar", "baz"], $titlePath);
     }
 
     public function testTitlePathJsonSerialization(): void
@@ -52,6 +52,6 @@ class TestResultTest extends TestCase
         /** @psalm-var object{titlePath: list<string>} $decodedJson */
         $decodedJson = json_decode(json_encode($testResult));
 
-        self::assertEquals($decodedJson->titlePath, ["foo", "bar", "baz"]);
+        self::assertEquals(["foo", "bar", "baz"], $decodedJson->titlePath);
     }
 }


### PR DESCRIPTION
### Context

Allure Report 3.2.0 has introduced global attachments and errors: report-wide information that is not tied to a particular test.

This PR extends the Allure API to allow producing global errors and attachments at runtime.

### API changes

#### 1. New `Allure::globalAttachment` function:

Examples:

```php
Allure::globalAttachment("text", "Lorem Ipsum");
```

```php
Allure::globalAttachment("config", '{ "name": "my-project" }', "application/json");
```

```php
Allure::globalAttachment("response", $responseText, "text/markdown", ".md");
```

#### 2. New `Allure::globalAttachmentFile` function:

Examples:

```php
Allure::globalAttachmentFile("machine-log", "./logs/trace.log");
```

```php
Allure::globalAttachmentFile("machine list", "./machine-list.json, "application/json");
```

```php
Allure::globalAttachmentFile("README", "./README.md, "text/markdown", ".md");
```

#### 3. New `Allure::globalError` function:

Examples:

```php
try
{
    // ...
}
catch (Throwable $e)
{
    Allure::globalError($e);
}
```

```php
Allure::globalError("A critical error has occured. The test process will be terminated");
```

```php
Allure::globalError(
    message: "A critical error has occured. The test process will be terminated",
    trace: "Exception: teardown failed\n    at \MyOrg\Demo\Teardown",
);
```

### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
