### PR TITLE
Make Allure result files durable before publishing

### DIFF
--- a/src/Io/FileSystemResultsWriter.php
+++ b/src/Io/FileSystemResultsWriter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Qameta\Allure\Io;
 
 use JsonException;
@@ -17,16 +19,23 @@ use Qameta\Allure\Model\Globals;
 use Qameta\Allure\Model\TestResult;
 use Throwable;
 
+use function bin2hex;
+use function dirname;
 use function error_clear_last;
 use function error_get_last;
 use function fclose;
+use function fflush;
 use function file_exists;
 use function fopen;
+use function function_exists;
 use function is_dir;
 use function mkdir;
+use function random_bytes;
 use function realpath;
+use function rename;
 use function rtrim;
 use function stream_copy_to_stream;
+use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -50,10 +59,17 @@ class FileSystemResultsWriter implements ResultsWriterInterface
 
     private string $outputDirectory;
 
-    public function __construct(string $outputDirectory, LoggerInterface $logger)
-    {
+    /** @var callable|null */
+    private $syncCallback;
+
+    public function __construct(
+        string $outputDirectory,
+        LoggerInterface $logger,
+        ?callable $syncCallback = null,
+    ) {
         $this->outputDirectory = rtrim($outputDirectory, '\\/');
         $this->logger = $logger;
+        $this->syncCallback = $syncCallback;
     }
 
     /**
@@ -115,15 +131,34 @@ class FileSystemResultsWriter implements ResultsWriterInterface
             if ($this->shouldCreateOutputDirectory()) {
                 $this->createOutputDirectory();
             }
-            $file = $this->getRealOutputDirectory() . DIRECTORY_SEPARATOR . $target;
-            $targetStream = $this->createTargetStream($file);
+            $directory = $this->getRealOutputDirectory();
+            $finalFile = $directory . DIRECTORY_SEPARATOR . $target;
+            $tempFile = $this->createTempPath($directory);
+            $published = false;
+            $synced = false;
             try {
-                $this->copyStream($sourceStream, $targetStream);
+                $targetStream = $this->createTargetStream($tempFile);
+                try {
+                    $this->copyStream($sourceStream, $targetStream);
+                    $this->syncTargetStream($targetStream);
+                    $synced = true;
+                } finally {
+                    error_clear_last();
+                    $closeResult = @fclose($targetStream);
+                    if (!$closeResult) {
+                        $this->logLastError('Target stream not closed', error_get_last());
+                    }
+                }
+                $this->publishFile($tempFile, $finalFile);
+                $published = true;
+                $tempFile = null;
             } finally {
-                error_clear_last();
-                $closeResult = @fclose($targetStream);
-                if (!$closeResult) {
-                    $this->logLastError('Target stream not closed', error_get_last());
+                if (!$published && !$synced && null !== $tempFile) {
+                    error_clear_last();
+                    $unlinkResult = @unlink($tempFile);
+                    if (!$unlinkResult) {
+                        $this->logLastError('Incomplete temp file not removed', error_get_last());
+                    }
                 }
             }
         } finally {
@@ -176,6 +211,120 @@ class FileSystemResultsWriter implements ResultsWriterInterface
             $error = error_get_last();
             throw new StreamCopyFailedException($error['message'] ?? null);
         }
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private function syncTargetStream($stream): void
+    {
+        if (null !== $this->syncCallback) {
+            ($this->syncCallback)($stream);
+
+            return;
+        }
+
+        $this->syncStream($stream);
+    }
+
+    /**
+     * @param resource $stream
+     */
+    protected function syncStream($stream): void
+    {
+        error_clear_last();
+        $flushResult = @fflush($stream);
+        if (!$flushResult) {
+            $error = error_get_last();
+            throw new IoFailedException($error['message'] ?? 'Failed to flush stream');
+        }
+        if (function_exists('fsync')) {
+            error_clear_last();
+            /** @var callable(resource):bool $fsync */
+            $fsync = 'fsync';
+            $syncResult = @$fsync($stream);
+            if (!$syncResult) {
+                $error = error_get_last();
+                throw new IoFailedException($error['message'] ?? 'Failed to sync stream');
+            }
+        }
+    }
+
+    /**
+     * Atomically publish a fully written temp file as the final artifact.
+     *
+     * @throws IoFailedException
+     */
+    protected function publishFile(string $tempFile, string $finalFile): void
+    {
+        if ($this->renamePath($tempFile, $finalFile)) {
+            return;
+        }
+        $renameError = error_get_last();
+
+        if (!file_exists($finalFile)) {
+            throw new IoFailedException(
+                $renameError['message'] ?? "Failed to rename {$tempFile} to {$finalFile}",
+            );
+        }
+
+        // Windows (and similar): rename over an existing file may fail. Move the old
+        // final aside, then publish the staged temp, then delete the aside backup.
+        $directory = dirname($finalFile);
+        $asideFile = $this->createTempPath($directory);
+
+        if (!$this->renamePath($finalFile, $asideFile)) {
+            $error = error_get_last();
+            throw new IoFailedException(
+                $error['message'] ?? "Failed to move aside existing file {$finalFile}",
+            );
+        }
+
+        if (!$this->renamePath($tempFile, $finalFile)) {
+            $error = error_get_last();
+            if (!$this->renamePath($asideFile, $finalFile)) {
+                $restoreError = error_get_last();
+                $this->logLastError(
+                    'Failed to restore aside backup to final path',
+                    $restoreError,
+                );
+                throw new IoFailedException(
+                    sprintf(
+                        'Failed to rename %s to %s; previous file left at %s%s',
+                        $tempFile,
+                        $finalFile,
+                        $asideFile,
+                        isset($restoreError['message']) ? ': ' . $restoreError['message'] : '',
+                    ),
+                );
+            }
+            throw new IoFailedException(
+                $error['message']
+                    ?? $renameError['message']
+                    ?? "Failed to rename {$tempFile} to {$finalFile}",
+            );
+        }
+
+        error_clear_last();
+        $unlinkResult = @unlink($asideFile);
+        if (!$unlinkResult) {
+            $this->logLastError('Aside backup not removed', error_get_last());
+        }
+    }
+
+    /**
+     * @return bool True when the rename succeeds.
+     */
+    protected function renamePath(string $from, string $to): bool
+    {
+        error_clear_last();
+
+        return @rename($from, $to);
+    }
+
+    private function createTempPath(string $directory): string
+    {
+        return $directory . DIRECTORY_SEPARATOR . '.allure-write-' . bin2hex(random_bytes(8)) . '.tmp';
     }
 
     /**

--- a/test/Io/FileSystemResultsWriterTest.php
+++ b/test/Io/FileSystemResultsWriterTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Qameta\Allure\Test\Io;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Qameta\Allure\Io\Exception\IoFailedException;
+use Qameta\Allure\Io\FileSystemResultsWriter;
+use Qameta\Allure\Io\StringDataSource;
+use Qameta\Allure\Model\AttachmentResult;
+use Qameta\Allure\Model\ContainerResult;
+use Qameta\Allure\Model\Globals;
+use Qameta\Allure\Model\TestResult;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function fflush;
+use function file_get_contents;
+use function file_put_contents;
+use function function_exists;
+use function glob;
+use function in_array;
+use function is_dir;
+use function json_decode;
+use function mkdir;
+use function rmdir;
+use function scandir;
+use function strpos;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+use const DIRECTORY_SEPARATOR;
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * @covers \Qameta\Allure\Io\FileSystemResultsWriter
+ */
+class FileSystemResultsWriterTest extends TestCase
+{
+    private string $outputDirectory;
+
+    public function setUp(): void
+    {
+        $this->outputDirectory = sys_get_temp_dir()
+            . DIRECTORY_SEPARATOR
+            . 'allure-fs-writer-'
+            . uniqid('', true);
+        mkdir($this->outputDirectory, 0777, true);
+    }
+
+    public function tearDown(): void
+    {
+        if (!is_dir($this->outputDirectory)) {
+            return;
+        }
+        $entries = scandir($this->outputDirectory);
+        if (false === $entries) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            @unlink($this->outputDirectory . DIRECTORY_SEPARATOR . $entry);
+        }
+        @rmdir($this->outputDirectory);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWriteTest_SuccessfulPublish_CreatesFinalJsonWithoutLeftoverTemps(): void
+    {
+        $uuid = 'test-uuid-1';
+        $writer = new FileSystemResultsWriter($this->outputDirectory, new NullLogger());
+        $writer->writeTest(new TestResult($uuid));
+
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-result.json';
+        self::assertFileExists($final);
+        /** @var array $decoded */
+        $decoded = json_decode((string) file_get_contents($final), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($uuid, $decoded['uuid'] ?? null);
+        $this->assertNoStagingTemps();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWriteContainer_SuccessfulPublish_CreatesFinalJsonWithoutLeftoverTemps(): void
+    {
+        $uuid = 'container-uuid-1';
+        $writer = new FileSystemResultsWriter($this->outputDirectory, new NullLogger());
+        $writer->writeContainer(new ContainerResult($uuid));
+
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-container.json';
+        self::assertFileExists($final);
+        /** @var array $decoded */
+        $decoded = json_decode((string) file_get_contents($final), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($uuid, $decoded['uuid'] ?? null);
+        $this->assertNoStagingTemps();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWriteGlobals_SuccessfulPublish_CreatesFinalJsonWithoutLeftoverTemps(): void
+    {
+        $uuid = 'globals-uuid-1';
+        $writer = new FileSystemResultsWriter($this->outputDirectory, new NullLogger());
+        $writer->writeGlobals(new Globals($uuid));
+
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-globals.json';
+        self::assertFileExists($final);
+        /** @var array $decoded */
+        $decoded = json_decode((string) file_get_contents($final), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($uuid, $decoded['uuid'] ?? null);
+        $this->assertNoStagingTemps();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWriteAttachment_WithStringData_CreatesFinalFileWithoutLeftoverTemps(): void
+    {
+        $uuid = 'attachment-uuid-1';
+        $writer = new FileSystemResultsWriter($this->outputDirectory, new NullLogger());
+        $attachment = new AttachmentResult($uuid);
+        $writer->writeAttachment($attachment, new StringDataSource('hello-attachment'));
+
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-attachment';
+        self::assertFileExists($final);
+        self::assertSame('hello-attachment', file_get_contents($final));
+        $this->assertNoStagingTemps();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWriteAttachment_OverwriteSameSourceTwice_LeavesLatestContentWithoutTemps(): void
+    {
+        $uuid = 'attachment-uuid-2';
+        $writer = new FileSystemResultsWriter($this->outputDirectory, new NullLogger());
+        $attachment = new AttachmentResult($uuid);
+        $writer->writeAttachment($attachment, new StringDataSource('first'));
+        $writer->writeAttachment($attachment, new StringDataSource('second-final'));
+
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-attachment';
+        self::assertFileExists($final);
+        self::assertSame('second-final', file_get_contents($final));
+        $this->assertNoStagingTemps();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWrite_SuccessfulPublish_InvokesSyncCallbackOnce(): void
+    {
+        $syncCalls = 0;
+        $writer = new FileSystemResultsWriter(
+            $this->outputDirectory,
+            new NullLogger(),
+            /**
+             * @param resource $stream
+             */
+            static function ($stream) use (&$syncCalls): void {
+                ++$syncCalls;
+                fflush($stream);
+                if (function_exists('fsync')) {
+                    /** @var callable(resource):bool $fsync */
+                    $fsync = 'fsync';
+                    $fsync($stream);
+                }
+            },
+        );
+        $writer->writeTest(new TestResult('sync-uuid-1'));
+
+        self::assertSame(1, $syncCalls);
+        $this->assertNoStagingTemps();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testWrite_FailedPublishAfterSync_KeepsStagedTemp(): void
+    {
+        $uuid = 'publish-fail-uuid';
+        $writer = new class ($this->outputDirectory, new NullLogger()) extends FileSystemResultsWriter {
+            protected function publishFile(string $tempFile, string $finalFile): void
+            {
+                throw new IoFailedException('simulated publish failure');
+            }
+        };
+
+        try {
+            $writer->writeTest(new TestResult($uuid));
+            self::fail('Expected IoFailedException');
+        } catch (IoFailedException $e) {
+            self::assertStringContainsString('simulated publish failure', $e->getMessage());
+        }
+
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-result.json';
+        self::assertFileDoesNotExist($final);
+
+        $temps = $this->listStagingTemps('.allure-write-*.tmp');
+        self::assertCount(1, $temps);
+        /** @var array $decoded */
+        $decoded = json_decode((string) file_get_contents($temps[0]), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($uuid, $decoded['uuid'] ?? null);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testPublishFile_ReplaceFailsAndRestoreSucceeds_RestoresOldFinalAndKeepsTemp(): void
+    {
+        $uuid = 'restore-ok-uuid';
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-result.json';
+        file_put_contents($final, '{"uuid":"old"}');
+
+        $writer = new class ($this->outputDirectory, new NullLogger()) extends FileSystemResultsWriter {
+            private int $renameCalls = 0;
+
+            protected function renamePath(string $from, string $to): bool
+            {
+                ++$this->renameCalls;
+                // 1: temp→final (Windows-style fail while final exists)
+                if (1 === $this->renameCalls) {
+                    return false;
+                }
+                // 3: temp→final after aside — fail without moving
+                if (3 === $this->renameCalls) {
+                    return false;
+                }
+                // 2: final→aside, 4: aside→final restore
+                return parent::renamePath($from, $to);
+            }
+        };
+
+        try {
+            $writer->writeTest(new TestResult($uuid));
+            self::fail('Expected IoFailedException');
+        } catch (IoFailedException $e) {
+            self::assertStringContainsString('Failed to rename', $e->getMessage());
+            self::assertStringNotContainsString('previous file left at', $e->getMessage());
+        }
+
+        self::assertFileExists($final);
+        self::assertSame('{"uuid":"old"}', file_get_contents($final));
+
+        $temps = $this->listStagingTemps('.allure-write-*.tmp');
+        self::assertCount(1, $temps);
+        /** @var array $decoded */
+        $decoded = json_decode((string) file_get_contents($temps[0]), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($uuid, $decoded['uuid'] ?? null);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testPublishFile_ReplaceAndRestoreBothFail_KeepsTempAndAside(): void
+    {
+        $uuid = 'restore-fail-uuid';
+        $final = $this->outputDirectory . DIRECTORY_SEPARATOR . $uuid . '-result.json';
+        file_put_contents($final, '{"uuid":"old"}');
+
+        $writer = new class ($this->outputDirectory, new NullLogger()) extends FileSystemResultsWriter {
+            private int $renameCalls = 0;
+
+            protected function renamePath(string $from, string $to): bool
+            {
+                ++$this->renameCalls;
+                // 1: temp→final fail (enter aside path)
+                // 3: temp→final after aside fail
+                // 4: aside→final restore fail
+                if (in_array($this->renameCalls, [1, 3, 4], true)) {
+                    return false;
+                }
+                // 2: final→aside
+                return parent::renamePath($from, $to);
+            }
+        };
+
+        try {
+            $writer->writeTest(new TestResult($uuid));
+            self::fail('Expected IoFailedException');
+        } catch (IoFailedException $e) {
+            self::assertStringContainsString('previous file left at', $e->getMessage());
+        }
+
+        self::assertFileDoesNotExist($final);
+
+        $temps = $this->listStagingTemps('.allure-write-*.tmp');
+        self::assertCount(2, $temps);
+
+        $contents = array_map(
+            static fn (string $path): string => (string) file_get_contents($path),
+            $temps,
+        );
+        self::assertContains('{"uuid":"old"}', $contents);
+        $newPayloads = array_filter(
+            $contents,
+            static fn (string $content): bool => false !== strpos($content, $uuid)
+                && '{"uuid":"old"}' !== $content,
+        );
+        self::assertCount(1, $newPayloads);
+    }
+
+    private function assertNoStagingTemps(): void
+    {
+        self::assertSame([], $this->listStagingTemps('*.tmp'));
+        self::assertSame([], $this->listStagingTemps('.allure-write-*'));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function listStagingTemps(string $pattern): array
+    {
+        $matches = glob($this->outputDirectory . DIRECTORY_SEPARATOR . $pattern);
+        if (false === $matches) {
+            return [];
+        }
+
+        return $matches;
+    }
+}


### PR DESCRIPTION
- Stage Allure filesystem artifacts (test/container/globals JSON and attachments) as `.allure-write-*.tmp` in the results directory, sync with `fflush` / `fsync` (when available), then rename to the final name so live readers do not see partially written finals.
- On overwrite platforms where rename-over-existing fails (typical Windows), move the old final aside, publish the staged file, then remove the aside backup; if publish fails after the aside step, restore the old final when possible and keep the staged temp with the new payload.
- Incomplete temps (failure before sync) are deleted; fully synced temps are kept if publish fails so the new payload is not lost.